### PR TITLE
Omit stripping domains from a FDQN Tango Host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .gitignore
 *.pyc
 *.py~
+.idea/
+

--- a/fandango/tango.py
+++ b/fandango/tango.py
@@ -128,9 +128,9 @@ def get_tango_host(dev_name='',use_db=False):
         elif use_db:
             use_db = use_db if hasattr(use_db,'get_db_host') else get_database()
             host,port = use_db.get_db_host(),int(use_db.get_db_port())
-            if matchCl('.*[a-z].*',host.lower()):
-              #Remove domain name
-              host = host.strip().split('.')[0]
+            # if matchCl('.*[a-z].*',host.lower()):
+            #   #Remove domain name
+            #   host = host.strip().split('.')[0]
             return "%s:%d"%(host,port)
         else:
             host = os.getenv('TANGO_HOST') 


### PR DESCRIPTION
If a Tango Host is given with FDQN and a reverse DNS is not configured (correct me here, if I'm wrong), we don't want to strip the domains from the Tango Host's hostname.
I'm not sure why would we want to strip the domains? Isn't accessing a machine with its FDQN safer?
Anyway, this fixes #2.