### PR TITLE
Enabling support for devices having names which end with .{number}

### DIFF
--- a/fandango/tango/defaults.py
+++ b/fandango/tango/defaults.py
@@ -116,7 +116,7 @@ no_alnum = '[^a-zA-Z0-9-_]'
 no_quotes = '(?:^|$|[^\'"a-zA-Z0-9_\./])'
 rehost = '(?:(?P<host>'+alnum+'(?:\.'+alnum+')?'+'(?:\.'+alnum+')?'\
     +'(?:\.'+alnum+')?'+'[\:][0-9]+)(?:/))' #(?:'+alnum+':[0-9]+/)?
-redev = '(?P<device>'+'(?:'+'/'.join([alnum]*3)+'))' #It matches a device name
+redev = '(?P<device>'+'(?:'+'/'.join([alnum]*3)+'(?:\.[0-9]+)?))' #It matches a device name
 reattr = '(?:/(?P<attribute>'+alnum\
     +')(?:(?:\\.)(?P<what>quality|time|value|exception|history))?)'
     #reattr matches attribute and extension

--- a/fandango/tango/tangoeval.py
+++ b/fandango/tango/tangoeval.py
@@ -185,7 +185,7 @@ class TangoEval(object):
     #THIS REGULAR EXPRESSIONS DOES NOT MATCH THE HOST IN THE FORMULA!!!; 
     #IT IS TAKEN AS PART OF THE DEVICE NAME!!
     #It matches a device name
-    redev = '(?P<device>(?:'+alnum+':[0-9]+/{1,2})?(?:'+'/'.join([alnum]*3)+'))' 
+    redev = '(?P<device>(?:'+alnum+':[0-9]+/{1,2})?(?:'+'/'.join([alnum]*3)+'(?:\.[0-9]+)?))'
     #Matches attribute and extension
     rewhat = '(?:(?:\\.)(?P<what>quality|time|value|exception|delta|all|'\
               'hist|ALARM|WARNING|VALID|INVALID|OK))?'


### PR DESCRIPTION
Hi, it is to let fandango and PANIC support SOLEIL's naming schema. 
It is related to the following Forum post:
http://www.tango-controls.org/community/forum/post/3632/
